### PR TITLE
Use the same logic to format message and asctime than the standard library. 

### DIFF
--- a/src/jsonlogger.py
+++ b/src/jsonlogger.py
@@ -1,7 +1,7 @@
 import logging
 import json
 import re
-from datetime import datetime
+
 
 class JsonFormatter(logging.Formatter):
     """A custom formatter to format logging records as json objects"""
@@ -12,24 +12,16 @@ class JsonFormatter(logging.Formatter):
 
     def format(self, record):
         """Formats a log record and serializes to json"""
-        mappings = {
-            'asctime': create_timestamp,
-            'message': lambda r: r.msg,
-        }
 
         formatters = self.parse()
 
+        record.message = record.getMessage()
+        # only format time if needed
+        if "asctime" in formatters:
+            record.asctime = self.formatTime(record, self.datefmt)
+
         log_record = {}
         for formatter in formatters:
-            try:
-                log_record[formatter] = mappings[formatter](record)
-            except KeyError:
-                log_record[formatter] = record.__dict__[formatter]
+            log_record[formatter] = record.__dict__[formatter]
 
         return json.dumps(log_record)
-
-def create_timestamp(record):
-    """Creates a human readable timestamp for a log records created date"""
-
-    timestamp = datetime.fromtimestamp(record.created)
-    return timestamp.strftime("%y-%m-%d %H:%M:%S,%f"),


### PR DESCRIPTION
Hello,

Can you please commit my changes.

This way we producte better message text on some circumstances when not logging
a string and use the date formater from the base class that uses the date format
configured from a file or a dict.

Now the "dateFmt" argument on the formater works and the way we make the message text is the same than on on the other formattters.

Thanks's
