### PR TITLE
Use trove classifiers from official list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ setup(
     test_suite = "tests.tests",
     install_requires = ['setuptools'],
     classifiers = [
-        'Development Status :: 1 - Alpha',
+        'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
-        'Operation System :: OS Independent',
+        'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Topic :: Logging',
+        'Topic :: System :: Logging',
     ]
 )


### PR DESCRIPTION
Hey,

i put your package up on the Python Package Index (https://pypi.python.org/pypi/python-json-logger).

While doing that, I had to align your classifiers in setup.py with https://pypi.python.org/pypi?%3Aaction=list_classifiers — those changes are attached.

I'd like to promote you as an admin to your package on PyPI, please tell me your PyPI user name.
