### PR TITLE
Fix the KeyError on formatter

### DIFF
--- a/src/jsonlogger.py
+++ b/src/jsonlogger.py
@@ -94,7 +94,7 @@ class JsonFormatter(logging.Formatter):
             log_record = {}
 
         for field in self._required_fields:
-            log_record[field] = record.__dict__[field]
+            log_record[field] = record.__dict__.get(field)
         log_record.update(extras)
         merge_record_extra(record, log_record, reserved=self._skip_fields)
 


### PR DESCRIPTION
When a custom (extra) formatter variable is specified but not provided by some logger, a KeyError is raised. Doing a dict.get(item) instead of dict[item] will prevent this from happening.
