### PR TITLE
Added ability to customise JSON dictionary

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -141,6 +141,17 @@ class TestJsonLogger(unittest.TestCase):
         self.assertEqual(logJson.get("adate"), "very custom")
         self.assertEqual(logJson.get("normal"), "value")
 
+    def testJsonCustomLogicAddsField(self):
+        class CustomJsonFormatter(jsonlogger.JsonFormatter):
+
+            def process_log_record(self, log_record):
+                log_record["custom"] = "value"
+
+        self.logHandler.setFormatter(CustomJsonFormatter())
+        self.logger.info("message")
+        logJson = json.loads(self.buffer.getvalue())
+        self.assertEqual(logJson.get("custom"), "value")
+
 
 if __name__ == '__main__':
     if len(sys.argv[1:]) > 0:


### PR DESCRIPTION
This implements the changes suggested in https://github.com/madzak/python-json-logger/issues/16. I have also renamed the `extras` variable as it doesn't actually contain the data from the `extra=` parameter, it contains the message if the message happens to be a dictionary.
