### PR TITLE
Allow editing of log_record in two possible ways

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -119,7 +119,7 @@ class JsonFormatter(logging.Formatter):
             log_record = {}
 
         self.add_fields(log_record, record, message_dict)
-        self.process_log_record(log_record)
+        log_record = self.process_log_record(log_record)
 
         return "%s%s" % (self.prefix,
                          json.dumps(log_record,


### PR DESCRIPTION
One more thing related to https://github.com/madzak/python-json-logger/issues/16: I just noticed that while `process_log_record` returns the `log_record`, that returned value isn't actually stored in a variable. By making the change in this commit, the user can use two approaches in `process_log_record` in a subclass to modify the `log_record`:
- modify the given `log_record` in `process_log_record` (in-place) and return that,
- or, use the given `log_record` to compute an entirely new dictionary instance and return that instead.
