### PR TITLE
Added "stack_info" as reserved attribute (introduced in Python 3.2)

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -19,7 +19,7 @@ RESERVED_ATTRS = (
     'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
     'funcName', 'levelname', 'levelno', 'lineno', 'module',
     'msecs', 'message', 'msg', 'name', 'pathname', 'process',
-    'processName', 'relativeCreated', 'thread', 'threadName')
+    'processName', 'relativeCreated', 'stack_info', 'thread', 'threadName')
 
 RESERVED_ATTR_HASH = dict(zip(RESERVED_ATTRS, RESERVED_ATTRS))
 


### PR DESCRIPTION
The attribute "stack_info" was added in Python 3.2 as a reserved attribute for log records.

I considered adding it only as a reserved word for Python 3.2+ code but it's probably better to make it reserved in earlier Python versions as well in anticipation of an update to Python 3.x.

https://docs.python.org/3/library/logging.html#logrecord-attributes