### PR TITLE
Handle error information in a more logical way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "python-json-logger",
-    version = "0.1.1",
+    version = "0.1.2",
     url = "http://github.com/madzak/python-json-logger",
     license = "BSD",
     description = "A python library adding a json log formatter",

--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -6,6 +6,9 @@ import logging
 import json
 import re
 import datetime
+import traceback
+
+from inspect import istraceback
 
 #Support order in python 2.7 and 3
 try:
@@ -73,6 +76,11 @@ class JsonFormatter(logging.Formatter):
                     return obj.isoformat()
                 elif isinstance(obj, datetime.time):
                     return obj.strftime('%H:%M')
+                elif istraceback(obj):
+                    tb = ''.join(traceback.format_tb(obj))
+                    return tb.strip()
+                elif isinstance(obj, Exception):
+                    return "Exception: %s" % str(obj)
                 return str(obj)
             self.json_default = _default_json_handler
         self._required_fields = self.parse()


### PR DESCRIPTION
Currently, fields in `exc_info` are serialized by simply calling str(), leading to a lack of exception and traceback information.

![https://i.imgur.com/XHNPdQ0.png](https://i.imgur.com/XHNPdQ0.png)

This PR adds support for proper serialization of traceback and exception types to ensure that the JSON result is usable for debugging.  The result:

![https://i.imgur.com/TQ7y1f6.png](https://i.imgur.com/TQ7y1f6.png)

Be aware that tests are currently failing against upstream master, and that issue is not introduced by, nor addressed in, this PR.