### PR TITLE
Add exception information to output when present.

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -121,6 +121,11 @@ class JsonFormatter(logging.Formatter):
         if "asctime" in self._required_fields:
             record.asctime = self.formatTime(record, self.datefmt)
 
+        # Display formatted exception, but allow overriding it in the
+        # user-supplied dict.
+        if record.exc_info and not message_dict.get('exc_info'):
+            message_dict['exc_info'] = self.formatException(record.exc_info)
+
         try:
             log_record = OrderedDict()
         except NameError:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@ import unittest
 import logging
 import json
 import sys
+import traceback
 
 try:
     import xmlrunner
@@ -153,6 +154,22 @@ class TestJsonLogger(unittest.TestCase):
         logJson = json.loads(self.buffer.getvalue())
         self.assertEqual(logJson.get("custom"), "value")
 
+    def testExcInfo(self):
+        fr = jsonlogger.JsonFormatter()
+        self.logHandler.setFormatter(fr)
+        try:
+            raise Exception('test')
+        except Exception:
+
+            self.logger.exception("hello")
+
+            expected_value = traceback.format_exc()
+            # Formatter removes trailing new line
+            if expected_value.endswith('\n'):
+                expected_value = expected_value[:-1]
+
+        logJson = json.loads(self.buffer.getvalue())
+        self.assertEqual(logJson.get("exc_info"), expected_value)
 
 if __name__ == '__main__':
     if len(sys.argv[1:]) > 0:


### PR DESCRIPTION
The standard formatter includes formatted exception information when log.exception is used. This pull request adds the same formatted exception under the key "exc_info" in the output JSON.

This is included in the message_dict, so a user can override the exc_info if it's set in the extra dict (or message dict). This also means that %(exc_info)s does not need to be included in the format string to include the exception information.

