### PR TITLE
Added a jsonify_log_record method to help testing.

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -109,6 +109,12 @@ class JsonFormatter(logging.Formatter):
         """
         return log_record
 
+    def jsonify_log_record(self, log_record):
+        """Returns a json string of the log record."""
+        return json.dumps(log_record,
+                          default=self.json_default,
+                          cls=self.json_encoder)
+
     def format(self, record):
         """Formats a log record and serializes to json"""
         message_dict = {}
@@ -134,7 +140,4 @@ class JsonFormatter(logging.Formatter):
         self.add_fields(log_record, record, message_dict)
         log_record = self.process_log_record(log_record)
 
-        return "%s%s" % (self.prefix,
-                         json.dumps(log_record,
-                                    default=self.json_default,
-                                    cls=self.json_encoder))
+        return "%s%s" % (self.prefix, self.jsonify_log_record(log_record))


### PR DESCRIPTION
Right now I'm implementing tests of a logging module, and would like to test the output of the `JsonFormatter` with the fields I'm supplying.  I can create an `OrderedDict` and dump it to json using the `json_default` and `json_encoder` attrs of `JsonFormatter`, but it would be better if my code didn't need to know the implementation details of `JsonFormatter`.  I think that this would be a generally useful abstraction to make.  