### PR TITLE
Suggestions: second are lost in default date serialization + XML test broken

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -67,15 +67,8 @@ class JsonFormatter(logging.Formatter):
         if not self.json_encoder and not self.json_default:
             def _default_json_handler(obj):
                 '''Prints dates in ISO format'''
-                if isinstance(obj, datetime.datetime):
-                    if obj.year < 1900:
-                        # strftime do not work with date < 1900
-                        return obj.isoformat()
-                    return obj.strftime(self.datefmt or '%Y-%m-%dT%H:%M')
-                elif isinstance(obj, datetime.date):
+                if isinstance(obj, (datetime.date, datetime.time)):
                     return obj.isoformat()
-                elif isinstance(obj, datetime.time):
-                    return obj.strftime('%H:%M')
                 elif istraceback(obj):
                     tb = ''.join(traceback.format_tb(obj))
                     return tb.strip()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -123,11 +123,11 @@ class TestJsonLogger(unittest.TestCase):
                "otherdatetimeagain": datetime.datetime(1900, 1, 1)}
         self.logger.info(msg)
         logJson = json.loads(self.buffer.getvalue())
-        self.assertEqual(logJson.get("adate"), "1999-12-31T23:59")
+	self.assertEqual(logJson.get("adate"), "1999-12-31T23:59:00")
         self.assertEqual(logJson.get("otherdate"), "1789-07-14")
         self.assertEqual(logJson.get("otherdatetime"), "1789-07-14T23:59:00")
         self.assertEqual(logJson.get("otherdatetimeagain"),
-                         "1900-01-01T00:00")
+                         "1900-01-01T00:00:00")
 
     def testJsonCustomDefault(self):
         def custom(o):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -123,7 +123,7 @@ class TestJsonLogger(unittest.TestCase):
                "otherdatetimeagain": datetime.datetime(1900, 1, 1)}
         self.logger.info(msg)
         logJson = json.loads(self.buffer.getvalue())
-	self.assertEqual(logJson.get("adate"), "1999-12-31T23:59:00")
+        self.assertEqual(logJson.get("adate"), "1999-12-31T23:59:00")
         self.assertEqual(logJson.get("otherdate"), "1789-07-14")
         self.assertEqual(logJson.get("otherdatetime"), "1789-07-14T23:59:00")
         self.assertEqual(logJson.get("otherdatetimeagain"),
@@ -175,7 +175,7 @@ if __name__ == '__main__':
     if len(sys.argv[1:]) > 0:
         if sys.argv[1] == 'xml':
             testSuite = unittest.TestLoader().loadTestsFromTestCase(
-                testJsonLogger)
+                TestJsonLogger)
             xmlrunner.XMLTestRunner(output='reports').run(testSuite)
     else:
         unittest.main()


### PR DESCRIPTION
Hi,

here are some suggestions:

* in the current default JSON serializer, seconds are lost in `datetime` instances
* in my opinion, the `datefmt` parameter to `logging.Formatter` instances should be used only to format the message time; not to serialize the data
* testJsonLogger has been renamed to TestJsonLogger

Regards.