### PR TITLE
Set exc_info to exc_text (if available) and if exc_info is not set

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -124,6 +124,8 @@ class JsonFormatter(logging.Formatter):
         # user-supplied dict.
         if record.exc_info and not message_dict.get('exc_info'):
             message_dict['exc_info'] = self.formatException(record.exc_info)
+        if not message_dict.get('exc_info') and record.exc_text:
+            message_dict['exc_info'] = record.exc_text
 
         try:
             log_record = OrderedDict()


### PR DESCRIPTION
I explain the reason and some background [here](https://github.com/amitsaha/python-json-logging/tree/master/multi_processes_queue_logger), let me know if you want me to write a test for it.