### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+install: pip install tox-travis
+script: tox
+matrix:
+  allow_failures:
+    - python: "2.6"

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/madzak/python-json-logger.svg?branch=master)](https://travis-ci.org/madzak/python-json-logger)
+
 Overview
 =======
 This library is provided to allow standard python logging to output log data as json objects. With JSON we can make our logs more readable by machines and we can stop writing custom parsers for syslog type records.


### PR DESCRIPTION
Tests for Python 2.6, 2.7, 3.2, 3.3, 3.4 are run in parallel.

Most scripting and interaction handled by [tox-travis][1] package.

Notes:

* [Python 3.1 envs not supported by Travis][2] and are omitted.
* Allow failure for Python 2.6 for the moment.

[1]: https://github.com/ryanhiebert/tox-travis
[2]: https://github.com/travis-ci/travis-ci/issues/1826