### PR TITLE
Python 2.6 test fix and travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,4 @@ python:
   - "3.4"
 install: pip install tox-travis
 script: tox
-matrix:
-  allow_failures:
-    - python: "2.6"
+


### PR DESCRIPTION
This encompasses #39 and #40 with the "addition" of removing Python 2.6 from the list of allowed failures. Merging this in will close those too.