### PR TITLE
Only support Python 2.7, 3.4, 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
-if sys.version_info < (2, 6):
-    print(sys.stderr, "{}: need Python 2.6 or later.".format(sys.argv[0]))
+if sys.version_info < (2, 7):
+    print(sys.stderr, "{}: need Python 2.7 or later.".format(sys.argv[0]))
     print(sys.stderr, "Your Python is {}".format(sys.version))
     sys.exit(1)
 
@@ -25,12 +25,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,5 @@
 [tox]
-envlist = py27, py31, py32, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 commands = python -m unittest discover
-
-[testenv:py26]
-commands = python -m discover
-deps = discover
-
-[testenv:py31]
-commands = python -m discover
-deps = discover


### PR DESCRIPTION
Python 2.6, Python 3.1, Python 3.2 and Python 3.3 have reached end-of-life: https://devguide.python.org/#status-of-python-branches.