### PR TITLE
Consistent control of stack_info

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -77,7 +77,7 @@ class JsonEncoder(json.JSONEncoder):
 class JsonFormatter(logging.Formatter):
     """
     A custom formatter to format logging records as json strings.
-    extra values will be formatted as str() if nor supported by
+    Extra values will be formatted as str() if not supported by
     json default encoder
     """
 
@@ -193,6 +193,10 @@ class JsonFormatter(logging.Formatter):
             message_dict['exc_info'] = self.formatException(record.exc_info)
         if not message_dict.get('exc_info') and record.exc_text:
             message_dict['exc_info'] = record.exc_text
+        # Display formatted record of stack frames
+        # default format is a string returned from :func:`traceback.print_stack`
+        if record.stack_info and not message_dict.get('stack_info'):
+            message_dict['stack_info'] = self.formatStack(record.stack_info)
 
         try:
             log_record = OrderedDict()


### PR DESCRIPTION
This commit aims to achieve consistent stack frames control
by `stack_info` flag in logging calls the same as that in python
logging module.
Currently, both a field named `stack_info` for JsonFormatter
and `stack_info=True` for logging function are needed for
stack frames to be properly displayed.
If `stack_info` field name is not passed, no output is given
irrespective of the `stack_info` flag in logging calls.
If `stack_info=False` in logging calls and `stack_info` is also
passed as one field for JsonFormatter, the output is `{"stack_info": null}`.
Above behavior is not very consistent and requires two controls
to output stack frames. This commit makes 'stack_info' flag in logging calls
as single point control of stack frames output and there is no need to
pass `stack_info` field into JsonFormatter.

JSON output log before this commit:
`{"asctime": "2019-03-05 18:43:41,454", "msg": "warning logged", "levelname": "WARNING", "filename": "jsonlogger_stack_info_test.py", "lineno": 27, "funcName": "<module>", "module": "jsonlogger_stack_info_test", "stack_info": null, "ts": "1552985021455"}`

 JSON ouput log after this commit:
`{"asctime": "2019-03-18 18:43:41,454", "msg": "warning with stack trace", "levelname": "WARNING", "filename": "jsonlogger_stack_info_test.py", "lineno": 28, "funcName": "<module>", "module": "jsonlogger_stack_info_test", "stack_info": "Stack (most recent call last):\n  File \"jsonlogger_stack_info_test.py\", line 28, in <module>\n    logger.warning(\"warning with stack trace\", stack_info=True)", "ts": "1552985021455"}`

