### PR TITLE
Move log record serialization to a separate method.

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -171,6 +171,10 @@ class JsonFormatter(logging.Formatter):
                                     indent=self.json_indent,
                                     ensure_ascii=self.json_ensure_ascii)
 
+    def serialize_log_record(self, log_record):
+        """Returns the final representation of the log record."""
+        return "%s%s" % (self.prefix, self.jsonify_log_record(log_record))
+
     def format(self, record):
         """Formats a log record and serializes to json"""
         message_dict = {}
@@ -206,4 +210,4 @@ class JsonFormatter(logging.Formatter):
         self.add_fields(log_record, record, message_dict)
         log_record = self.process_log_record(log_record)
 
-        return "%s%s" % (self.prefix, self.jsonify_log_record(log_record))
+        return self.serialize_log_record(log_record)


### PR DESCRIPTION
Hi. The purpose of this PR is to move the final log record serialization to a separate method from the main .format(). This will improve customization of the class. Here is my case:
I want to send logs to google stackdriver from my python application. I am using json-logger to get structured log record with all `extra` fields, but stackdriver python library won't parse a string that contains an encoded json you need to pass a python dict object to it. 
So I would like to use all features of the json-logger except actual json encoding to receive python dict objects as the output. 
What do you think?