### PR TITLE
Add timezone to timestamp

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -5,7 +5,7 @@ to output log data as JSON formatted strings
 import logging
 import json
 import re
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 import traceback
 import importlib
 
@@ -154,7 +154,7 @@ class JsonFormatter(logging.Formatter):
 
         if self.timestamp:
             key = self.timestamp if type(self.timestamp) == str else 'timestamp'
-            log_record[key] = datetime.utcnow()
+            log_record[key] = datetime.fromtimestamp(record.created, tz=timezone.utc)
 
     def process_log_record(self, log_record):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+import unittest.mock
 import logging
 import json
 import sys
@@ -7,12 +8,12 @@ import traceback
 import random
 
 try:
-    import xmlrunner
+    import xmlrunner  # noqa
 except ImportError:
     pass
 
 try:
-    from StringIO import StringIO
+    from StringIO import StringIO  # noqa
 except ImportError:
     # Python 3 Support
     from io import StringIO
@@ -130,6 +131,17 @@ class TestJsonLogger(unittest.TestCase):
         self.assertEqual(logJson.get("otherdatetime"), "1789-07-14T23:59:00")
         self.assertEqual(logJson.get("otherdatetimeagain"),
                          "1900-01-01T00:00:00")
+
+    @unittest.mock.patch('time.time', return_value=1500000000.0)
+    def testJsonDefaultEncoderWithTimestamp(self, time_mock):
+        fr = jsonlogger.JsonFormatter(timestamp=True)
+        self.logHandler.setFormatter(fr)
+
+        self.logger.info("Hello")
+
+        self.assertTrue(time_mock.called)
+        logJson = json.loads(self.buffer.getvalue())
+        self.assertEqual(logJson.get("timestamp"), "2017-07-14T02:40:00+00:00")
 
     def testJsonCustomDefault(self):
         def custom(o):


### PR DESCRIPTION
The "timestamp" field does not contain timezone information. If you don't live in GMT, that is probably wrong for you. This PR adds an additional "+000" to the serialized datetime.
Also, it uses the log creation timestamp, not whatever time it is when the field gets added.