### PR TITLE
Update examples and tests for Python 3.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 install: pip install tox-travis
 script: tox

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ formatter = CustomJsonFormatter('one;two')
 
 # is equivalent to:
 
-formatter = jsonlogger.JsonFormatter('(one) (two)')
+formatter = jsonlogger.JsonFormatter('%(one)s %(two)s')
 ```
 
 You can also add extra fields to your json output by specifying a dict in place of message, as well as by specifying an `extra={}` argument.
@@ -80,7 +80,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
         else:
             log_record['level'] = record.levelname
 
-formatter = CustomJsonFormatter('(timestamp) (level) (name) (message)')
+formatter = CustomJsonFormatter('%(timestamp)s %(level)s %(name)s %(message)s')
 ```
 
 Items added to the log record will be included in *every* log message, no matter what the format requires.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: System :: Logging',
     ]
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -62,7 +62,7 @@ class TestJsonLogger(unittest.TestCase):
             'threadName'
         ]
 
-        log_format = lambda x: ['%({0:s})'.format(i) for i in x]
+        log_format = lambda x: ['%({0:s})s'.format(i) for i in x]
         custom_format = ' '.join(log_format(supported_keys))
 
         fr = jsonlogger.JsonFormatter(custom_format)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37
+envlist = py34, py35, py36, py37, py38
 
 [testenv]
 commands = python -m unittest discover


### PR DESCRIPTION
See #86 
See #74 

This PR fixes up a couple of small issues encountered when upgrading to Python 3.8:
- updates examples in `README.md` to be compatible with Python 3.8
- updates test code to match the formatting example provided in the readme
- adds Python 3.8 testing to Travis and tox
- marks the package as Python 3.8 compatible in `setup.py`