### PR TITLE
correct path in tests for importing from src

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,7 +18,7 @@ except ImportError:
     # Python 3 Support
     from io import StringIO
 
-sys.path.append('src/python-json-logger')
+sys.path.append('src')
 from pythonjsonlogger import jsonlogger
 import datetime
 


### PR DESCRIPTION
Since the system path is being appended to include the folder for production code, it should have 'src' only, as opposed to including the hyphenated name of the library. This changes allows tests to be run locally with `python -m unittest` using Python 3.

Resolves https://github.com/madzak/python-json-logger/issues/102