### PR TITLE
use assertions to test if all supported keys are set

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -85,8 +85,8 @@ class TestJsonLogger(unittest.TestCase):
         log_json = json.loads(log_msg)
 
         for supported_key in supported_keys:
-            if supported_key in log_json:
-                self.assertTrue(True)
+            self.assertIn(supported_key, log_json)
+            self.assertIsNotNone(log_json[supported_key])
 
     def testUnknownFormatKey(self):
         fr = jsonlogger.JsonFormatter('%(unknown_key)s %(message)s')


### PR DESCRIPTION
Changes `testFormatKeys` to use assertions that will fail if any of the supported keys does not produce output in the formatted JSON.
Quality assurance - If any additional keys are added to `supported_keys`, the formatter will not find a value in the record, and the value in the output will be `None`, so `assertIsNotNone` will fail for that key.
Resolves https://github.com/madzak/python-json-logger/issues/103