### PR TITLE
Enable Universal Wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
-python-tag=py34
+universal=1


### PR DESCRIPTION
The purpose of this PR is to enable Universal Wheels in python-json-logger using the instructions outlined here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#id74

Context: The existing `python-tag=py34`  makes the command `pip wheel --no-binary python-json-logger --no-deps python-json-logger==2.0.1` use the `py34-none-any.whl`, but there's no such thing AFAIK.

It should also be possible to rm setup.cfg and everything will work fine, you could even publish a py3-none-any.whl file easily since this is a pure python package. 

