### PR TITLE
Jsonformatter formats the newline character

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -179,7 +179,7 @@ class JsonFormatter(logging.Formatter):
 
     def serialize_log_record(self, log_record):
         """Returns the final representation of the log record."""
-        return "%s%s" % (self.prefix, self.jsonify_log_record(log_record))
+        return "%s%s" % (self.prefix, self.jsonify_log_record(log_record).replace('\\n', '\n'))
 
     def format(self, record):
         """Formats a log record and serializes to json"""


### PR DESCRIPTION
Jsonformatter will not format the newline character that is inside the message fields too.

Ex:
without this commit
{
    "rid": "6c0320a4-ed87-4d0a-a668-b7ceef94eecf",
    "asctime": "2021-03-23 14:13:50,151",
    "filename": "<some-filename>",
    "module": "<some-module>",
    "funcName": "<some-function>",
    "lineno": 16,
    "levelname": "INFO",
    "message": "log line 1\nlog line 2"
}

After this commit
{
    "rid": "6c0320a4-ed87-4d0a-a668-b7ceef94eecf",
    "asctime": "2021-03-23 14:13:50,151",
    "filename": "<some-filename>",
    "module": "<some-module>",
    "funcName": "<some-function>",
    "lineno": 16,
    "levelname": "INFO",
    "message": "log line 1
log line 2"
}