### PR TITLE
Add PEP 561 marker

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,52 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 python-tag=py3
+
+[mypy]
+
+# For details on each flag, please see the mypy documentation at:
+# https://mypy.readthedocs.io/en/stable/config_file.html#config-file
+
+# Import Discovery
+mypy_path = src
+namespace_packages = true
+
+# Disallow dynamic typing
+disallow_any_unimported = true
+disallow_any_expr = false
+disallow_any_decorated = true
+disallow_any_explicit = true
+disallow_any_generics = false
+disallow_subclassing_any = true
+
+# Untyped definitions and calls
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+
+# None and Optional handling
+no_implicit_optional = true
+
+# Configuring warnings
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = true
+warn_unreachable = true
+
+# Miscellaneous strictness flags
+implicit_reexport = true
+strict_equality = true
+
+# Configuring error messages
+show_error_context = true
+show_column_numbers = true
+show_error_codes = true
+pretty = true
+show_absolute_path = true
+
+# Miscellaneous
+warn_unused_configs = true
+verbosity = 0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     python_requires='>=3.5',
     test_suite="tests.tests",
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 6 - Mature',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -9,20 +9,22 @@ from datetime import date, datetime, time, timezone
 import traceback
 import importlib
 
+from typing import Dict, Union, List, Tuple
+
 from inspect import istraceback
 
 from collections import OrderedDict
 
 # skip natural LogRecord attributes
 # http://docs.python.org/library/logging.html#logrecord-attributes
-RESERVED_ATTRS = (
+RESERVED_ATTRS: Tuple[str, ...] = (
     'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
     'funcName', 'levelname', 'levelno', 'lineno', 'module',
     'msecs', 'message', 'msg', 'name', 'pathname', 'process',
     'processName', 'relativeCreated', 'stack_info', 'thread', 'threadName')
 
 
-def merge_record_extra(record, target, reserved):
+def merge_record_extra(record: logging.LogRecord, target: Dict, reserved: Union[Dict, List]) -> Dict:
     """
     Merges extra attributes from LogRecord object into target dictionary
 
@@ -138,7 +140,7 @@ class JsonFormatter(logging.Formatter):
         module = importlib.import_module(path)
         return getattr(module, function)
 
-    def parse(self):
+    def parse(self) -> List[str]:
         """
         Parses format string looking for substitutions
 
@@ -146,7 +148,11 @@ class JsonFormatter(logging.Formatter):
         to include in all log messages.
         """
         standard_formatters = re.compile(r'\((.+?)\)', re.IGNORECASE)
-        return standard_formatters.findall(self._fmt)
+
+        if self._fmt:
+            return standard_formatters.findall(self._fmt)
+        else:
+            return []
 
     def add_fields(self, log_record, record, message_dict):
         """
@@ -211,6 +217,7 @@ class JsonFormatter(logging.Formatter):
             # Python2.7 doesn't have stack_info.
             pass
 
+        log_record: Dict
         try:
             log_record = OrderedDict()
         except NameError:

--- a/src/pythonjsonlogger/py.typed
+++ b/src/pythonjsonlogger/py.typed
@@ -1,0 +1,1 @@
+# PEP-561 marker. https://mypy.readthedocs.io/en/latest/installed_packages.html

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,8 @@ python =
   3.10: py310
 
 [testenv]
-commands = python -m unittest discover
+deps =
+  mypy
+commands =
+  python -m unittest discover
+  mypy src


### PR DESCRIPTION
- Add a PEP 561 marker
- Add basic mypy configuration
- Run mypy from tox
- Minor code modifications to make mypy happy

This is intended to be a relatively minimal change just to enable basic type checking. Future changes should fill out the type annotations more and enable stricter mypy configuration (set all mypy options to 'true').

This change is a small step towards https://github.com/madzak/python-json-logger/issues/118

Note that the marker is intentionally not shipped via setup.py -- the annotations need more cleanup first (turn on a few key mypy config options, e.g. no-untyped-defs).