### PR TITLE
Drop Python 3.5 support and pypy 3.6 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ envlist = pypy3, py35, py36, py37, py38, py39, py310
 
 [gh-actions]
 python =
-  pypy-3: pypy3
-  3.5: py35
+  pypy-38: pypy38
   3.6: py36
   3.7: py37
   3.8: py38


### PR DESCRIPTION
To allow for typing annotations and enforcement of typing annotations,
we need to:

- Drop Python 3.5 support since it doesn't support the syntax
- Drop pypy 3.6 support since it doesn't support mypy