### PR TITLE
Drop Python 3.5 support and pypy 3.6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [pypy3, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-beta.4]
+        python-version: [pypy38, 3.6, 3.7, 3.8, 3.9, 3.10.0-beta.4]
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = pypy3, py35, py36, py37, py38, py39, py310
+envlist = pypy38, py36, py37, py38, py39, py310
 
 [gh-actions]
 python =
-  pypy-3: pypy3
-  3.5: py35
+  pypy-38: pypy38
   3.6: py36
   3.7: py37
   3.8: py38


### PR DESCRIPTION
To allow for typing annotations and enforcement of typing annotations,
we need to:

- Drop Python 3.5 support since it doesn't support the syntax
- Drop pypy 3.6 support since it doesn't support mypy

See https://github.com/madzak/python-json-logger/pull/129#issuecomment-1030708627 for additional background.