### PR TITLE
Remove unnecessary try-except around OrderedDict usage

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -226,12 +226,7 @@ class JsonFormatter(logging.Formatter):
             # Python2.7 doesn't have stack_info.
             pass
 
-        log_record: Dict
-        try:
-            log_record = OrderedDict()
-        except NameError:
-            log_record = {}
-
+        log_record = OrderedDict()
         self.add_fields(log_record, record, message_dict)
         log_record = self.process_log_record(log_record)
 


### PR DESCRIPTION
since 88838bd9 `OrderedDict` is imported unconditionally, so there is no need anymore for a `try-except NameError` anymore