### PR TITLE
Fix too strict regex for pecentage style logging

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -146,7 +146,7 @@ class JsonFormatter(logging.Formatter):
 
         This method is responsible for returning a list of fields (as strings)
         to include in all log messages.
-        """        
+        """
         if isinstance(self._style, logging.StringTemplateStyle):
             formatter_style_pattern = re.compile(r'\$\{(.+?)\}', re.IGNORECASE)
         elif isinstance(self._style, logging.StrFormatStyle):
@@ -154,7 +154,7 @@ class JsonFormatter(logging.Formatter):
         # PercentStyle is parent class of StringTemplateStyle and StrFormatStyle so
         # it needs to be checked last.
         elif isinstance(self._style, logging.PercentStyle):
-            formatter_style_pattern = re.compile(r'%\((.+?)\)s', re.IGNORECASE)
+            formatter_style_pattern = re.compile(r'%\((.+?)\)', re.IGNORECASE)
         else:
             raise ValueError('Invalid format: %s' % self._fmt)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -42,6 +42,20 @@ class TestJsonLogger(unittest.TestCase):
 
         self.assertEqual(logJson["message"], msg)
 
+    def testPercentageFormat(self):
+        fr = jsonlogger.JsonFormatter(
+            # All kind of different styles to check the regex
+            '[%(levelname)8s] %(message)s %(filename)s:%(lineno)d %(asctime)'
+        )
+        self.logHandler.setFormatter(fr)
+
+        msg = "testing logging format"
+        self.logger.info(msg)
+        logJson = json.loads(self.buffer.getvalue())
+
+        self.assertEqual(logJson["message"], msg)
+        self.assertEqual(logJson.keys(), {'levelname', 'message', 'filename', 'lineno', 'asctime'})
+
     def testRenameBaseField(self):
         fr = jsonlogger.JsonFormatter(rename_fields={'message': '@message'})
         self.logHandler.setFormatter(fr)


### PR DESCRIPTION
The regression was introduced in 0055dc5b273949ee7432665eeddbe37781d9dc01.

Only fields followed by an `s` were correctly extracted.
As there are other possible cases like `8s`, `d`, or no prefix at all the regex is loosened.

In this funky case `[%(levelname)8s][PID %(process)d][%(threadName)s]` the extracted field was `levelname)8s][PID %(process)d][%(threadName`.