### PR TITLE
Drop old python version support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,16 @@
 build
 dist
 *.egg-info
+
+# Tests and validation
 .tox/
+.mypy_cache
+
+# Python's venv
 .env
+.venv
 env
+
+# IDE
 .vscode
+.idea

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-python-tag=py3
-
 [mypy]
 
 # For details on each flag, please see the mypy documentation at:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages("src", exclude="tests"),
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     test_suite="tests.tests",
     classifiers=[
         'Development Status :: 6 - Mature',

--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -221,15 +221,10 @@ class JsonFormatter(logging.Formatter):
             message_dict['exc_info'] = record.exc_text
         # Display formatted record of stack frames
         # default format is a string returned from :func:`traceback.print_stack`
-        try:
-            if record.stack_info and not message_dict.get('stack_info'):
-                message_dict['stack_info'] = self.formatStack(record.stack_info)
-        except AttributeError:
-            # Python2.7 doesn't have stack_info.
-            pass
+        if record.stack_info and not message_dict.get('stack_info'):
+            message_dict['stack_info'] = self.formatStack(record.stack_info)
 
-        log_record: Dict[str, Any]
-        log_record = OrderedDict()
+        log_record: Dict[str, Any] = OrderedDict()
         self.add_fields(log_record, record, message_dict)
         log_record = self.process_log_record(log_record)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,11 +12,7 @@ try:
 except ImportError:
     pass
 
-try:
-    from StringIO import StringIO  # noqa
-except ImportError:
-    # Python 3 Support
-    from io import StringIO
+from io import StringIO
 
 sys.path.append('src/python-json-logger')
 from pythonjsonlogger import jsonlogger
@@ -77,7 +73,6 @@ class TestJsonLogger(unittest.TestCase):
 
         self.assertEqual(logJson["log_stream"], "kafka")
         self.assertEqual(logJson["message"], msg)
-
 
     def testFormatKeys(self):
         supported_keys = [
@@ -257,6 +252,7 @@ class TestJsonLogger(unittest.TestCase):
         self.logger.info(" message", extra=value)
         msg = self.buffer.getvalue()
         self.assertEqual(msg, "{\"message\": \" message\", \"special\": [3.0, 8.0]}\n")
+
 
 if __name__ == '__main__':
     if len(sys.argv[1:]) > 0:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = pypy38, py36, py37, py38, py39, py310
+envlist = pypy38, py37, py38, py39, py310
 
 [gh-actions]
 python =
   pypy-3.8: pypy38
-  3.6: py36
   3.7: py37
   3.8: py38
   3.9: py39


### PR DESCRIPTION
Address the issue #153 

Python2 sunset was in the January 1st 2020: https://www.python.org/doc/sunset-python-2/

`python3.5` and `python3.6` EOL dates are also passed: https://endoflife.date/python