### PR TITLE
Add `py.typed` to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author="Zakaria Zajac",
     author_email="zak@madzak.com",
     package_dir={'': 'src'},
+    package_data={"src/pythonjsonlogger": ["py.typed"]},
     packages=find_packages("src", exclude="tests"),
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
     python_requires='>=3.5',


### PR DESCRIPTION
I'm trying to use `python-json-logger` in my project, but `mypy` is surfacing this error:

```text
error: Skipping analyzing "pythonjsonlogger": module is installed, but missing library stubs or py.typed marker
note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

I believe there is an open issue related to this: https://github.com/madzak/python-json-logger/issues/118
My guess why this continues to happen even though `py.typed` exists in the repo is because it isn't added to the package.