### PR TITLE
Fix rename_fields for exc_info

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -168,10 +168,8 @@ class JsonFormatter(logging.Formatter):
         Override this method to implement custom logic for adding fields.
         """
         for field in self._required_fields:
-            if field in self.rename_fields:
-                log_record[self.rename_fields[field]] = record.__dict__.get(field)
-            else:
-                log_record[field] = record.__dict__.get(field)
+            log_record[field] = record.__dict__.get(field)
+
         log_record.update(self.static_fields)
         log_record.update(message_dict)
         merge_record_extra(record, log_record, reserved=self._skip_fields)
@@ -179,6 +177,13 @@ class JsonFormatter(logging.Formatter):
         if self.timestamp:
             key = self.timestamp if type(self.timestamp) == str else 'timestamp'
             log_record[key] = datetime.fromtimestamp(record.created, tz=timezone.utc)
+
+        self._perform_rename_log_fields(log_record)
+
+    def _perform_rename_log_fields(self, log_record):
+        for old_field_name, new_field_name in self.rename_fields.items():
+            log_record[new_field_name] = log_record[old_field_name]
+            del log_record[old_field_name]
 
     def process_log_record(self, log_record):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -62,17 +62,17 @@ class TestJsonLogger(unittest.TestCase):
 
         self.assertEqual(log_json["@message"], msg)
 
-    def testRenameNonexistentField(self):
+    def test_rename_nonexistent_field(self):
         fr = jsonlogger.JsonFormatter(rename_fields={'nonexistent_key': 'new_name'})
-        self.logHandler.setFormatter(fr)
+        self.log_handler.setFormatter(fr)
 
         stderr_watcher = StringIO()
         sys.stderr = stderr_watcher
-        self.logger.info("testing logging rename")
+        self.log.info("testing logging rename")
 
         self.assertTrue("KeyError: 'nonexistent_key'" in stderr_watcher.getvalue())
 
-    def testAddStaticFields(self):
+    def test_add_static_fields(self):
         fr = jsonlogger.JsonFormatter(static_fields={'log_stream': 'kafka'})
 
         self.log_handler.setFormatter(fr)
@@ -212,7 +212,6 @@ class TestJsonLogger(unittest.TestCase):
         self.log.info("message")
         log_json = json.loads(self.buffer.getvalue())
         self.assertEqual(log_json.get("custom"), "value")
-
 
     def get_traceback_from_exception_followed_by_log_call(self) -> str:
         try:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -62,6 +62,16 @@ class TestJsonLogger(unittest.TestCase):
 
         self.assertEqual(logJson["@message"], msg)
 
+    def testRenameNonexistentField(self):
+        fr = jsonlogger.JsonFormatter(rename_fields={'nonexistent_key': 'new_name'})
+        self.logHandler.setFormatter(fr)
+
+        stderr_watcher = StringIO()
+        sys.stderr = stderr_watcher
+        self.logger.info("testing logging rename")
+
+        self.assertTrue("KeyError: 'nonexistent_key'" in stderr_watcher.getvalue())
+
     def testAddStaticFields(self):
         fr = jsonlogger.JsonFormatter(static_fields={'log_stream': 'kafka'})
 


### PR DESCRIPTION
Current `rename_fields` feature does not work for `exc_info`, as said in [this comment](https://github.com/madzak/python-json-logger/issues/36#issuecomment-732769603).

I've changed how the rename works and added a few more tests.