### PR TITLE
Make argument optional

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -9,7 +9,7 @@ from datetime import date, datetime, time, timezone
 import traceback
 import importlib
 
-from typing import Any, Dict, Union, List, Tuple
+from typing import Any, Dict, Optional, Union, List, Tuple
 
 from inspect import istraceback
 
@@ -25,7 +25,12 @@ RESERVED_ATTRS: Tuple[str, ...] = (
 
 
 
-def merge_record_extra(record: logging.LogRecord, target: Dict, reserved: Union[Dict, List], rename_fields: Dict[str,str]) -> Dict:
+def merge_record_extra(
+    record: logging.LogRecord,
+    target: Dict,
+    reserved: Union[Dict, List],
+    rename_fields: Optional[Dict[str,str]] = None,
+) -> Dict:
     """
     Merges extra attributes from LogRecord object into target dictionary
 
@@ -35,6 +40,8 @@ def merge_record_extra(record: logging.LogRecord, target: Dict, reserved: Union[
     :param rename_fields: an optional dict, used to rename field names in the output.
             Rename levelname to log.level: {'levelname': 'log.level'}
     """
+    if rename_fields is None:
+        rename_fields = {}
     for key, value in record.__dict__.items():
         # this allows to have numeric keys
         if (key not in reserved

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -298,6 +298,14 @@ class TestJsonLogger(unittest.TestCase):
         msg = self.buffer.getvalue()
         self.assertEqual(msg, '{"error.type": null, "error.message": null, "log.origin.function": "test_rename_reserved_attrs", "log.level": "INFO", "log.origin.file.name": "tests", "process.name": "MainProcess", "process.thread.name": "MainThread", "log.message": "message"}\n')
 
+    def test_merge_record_extra(self):
+        record = logging.LogRecord("name", level=1, pathname="", lineno=1, msg="Some message", args=None, exc_info=None)
+        output = jsonlogger.merge_record_extra(record, target=dict(foo="bar"), reserved=[])
+        self.assertIn("foo", output)
+        self.assertIn("msg", output)
+        self.assertEquals(output["foo"], "bar")
+        self.assertEquals(output["msg"], "Some message")
+
 
 if __name__ == '__main__':
     if len(sys.argv[1:]) > 0:


### PR DESCRIPTION
Fixes https://github.com/madzak/python-json-logger/issues/163

## Why?
In version `2.0.5` a new, non-optional argument to `merge_record_extra` was added, making the version non-backward-compatible.

## What?
- Make that new argument optional.
- Add test case making sure the method can be called without the argument.