### PR TITLE
Fix inclusion of `py.typed` in pip packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author="Zakaria Zajac",
     author_email="zak@madzak.com",
     package_dir={'': 'src'},
-    package_data={"src/pythonjsonlogger": ["py.typed"]},
+    package_data={"pythonjsonlogger": ["py.typed"]},
     packages=find_packages("src", exclude="tests"),
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
     python_requires=">=3.6",


### PR DESCRIPTION
The `py.typed` marker file, which indicates that the code has type annotations, is currently missing from the package files published on pypi. The reason is that the `package_data` dictionary in `setup.py` currently uses the key `"src/pythonjsonlogger"` where a package name, not a directory, is required (see [the example in the documentation][1]).

When the package name is used instead, `py.typed` gets packaged correctly.

  [1]: https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data