### PR TITLE
Fix error when passing a rename field that does not exist in the log record

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -229,8 +229,9 @@ class JsonFormatter(logging.Formatter):
 
     def _perform_rename_log_fields(self, log_record):
         for old_field_name, new_field_name in self.rename_fields.items():
-            log_record[new_field_name] = log_record[old_field_name]
-            del log_record[old_field_name]
+            if old_field_name in log_record:
+                log_record[new_field_name] = log_record[old_field_name]
+                del log_record[old_field_name]
 
     def process_log_record(self, log_record):
         """


### PR DESCRIPTION
Closes #171.

Added an exists check for the old_field_name before asigning a value to log_record[new_field_name].