### PR TITLE
only rename existing fields and keep the order

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -228,9 +228,9 @@ class JsonFormatter(logging.Formatter):
         self._perform_rename_log_fields(log_record)
 
     def _perform_rename_log_fields(self, log_record):
-        for old_field_name, new_field_name in self.rename_fields.items():
-            log_record[new_field_name] = log_record[old_field_name]
-            del log_record[old_field_name]
+        """Perform a substitution in place to maintain the order"""
+        for key, value in list(log_record.items()):
+            log_record[self.rename_fields.get(key, key)] = log_record.pop(key)
 
     def process_log_record(self, log_record):
         """

--- a/tests/test_jsonlogger.py
+++ b/tests/test_jsonlogger.py
@@ -62,15 +62,17 @@ class TestJsonLogger(unittest.TestCase):
 
         self.assertEqual(log_json["@message"], msg)
 
-    def test_rename_nonexistent_field(self):
-        fr = jsonlogger.JsonFormatter(rename_fields={'nonexistent_key': 'new_name'})
+    def test_rename_maintaining_order(self):
+        fr = jsonlogger.JsonFormatter(
+            "%(levelname)s %(message)s %(asctime)",
+            rename_fields={'levelname': 'level'}
+        )
+
         self.log_handler.setFormatter(fr)
+        self.log.info("testing rename while maintaining order")
+        log_json = json.loads(self.buffer.getvalue())
 
-        stderr_watcher = StringIO()
-        sys.stderr = stderr_watcher
-        self.log.info("testing logging rename")
-
-        self.assertTrue("KeyError: 'nonexistent_key'" in stderr_watcher.getvalue())
+        self.assertTrue(list(log_json.keys())[0] == "level")
 
     def test_add_static_fields(self):
         fr = jsonlogger.JsonFormatter(static_fields={'log_stream': 'kafka'})


### PR DESCRIPTION
## Changes effects:

* Fixes issue #169 
* Keep the original order when renaming fields;
* Ignore nonexisting fields, avoiding fields with empty values;
* No more raises an error while trying to rename non existing fields.