### PR TITLE
feat: add taskName to RESERVED_ATTRS

### DIFF
--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -39,6 +39,7 @@ RESERVED_ATTRS: Tuple[str, ...] = (
     "stack_info",
     "thread",
     "threadName",
+    "taskName",
 )
 
 OptionalCallableOrStr = Optional[Union[Callable, str]]


### PR DESCRIPTION
`taskName` was added in Python 3.12. See https://docs.python.org/3/library/logging.html