### PR TITLE
[FIX] README.md replace deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ Contents of these dictionaries will be added at the root level of the entry and 
 You can also use the `add_fields` method to add to or generally normalize the set of default set of fields, it is called for every log event. For example, to unify default fields with those provided by [structlog](http://www.structlog.org/) you could do something like this:
 
 ```python
+from datetime import datetime, UTC
+
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
         if not log_record.get('timestamp'):
             # this doesn't use record.created, so it is slightly off
-            now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            now = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
             log_record['timestamp'] = now
         if log_record.get('level'):
             log_record['level'] = log_record['level'].upper()


### PR DESCRIPTION
Method `utcnow` is deprecated and must be replaced with UTC object